### PR TITLE
String zu translation notes hinzufügen

### DIFF
--- a/TRANSLATION_NOTES_DE.asc
+++ b/TRANSLATION_NOTES_DE.asc
@@ -171,6 +171,8 @@ Staging-Area; Alternativ: Index
 Stash; Singular: der Stash; Plural: die Stashes
 |to stash|
 stashen; er/sie stasht; wir stashen; Deutsch: zum Stash hinzufügen, auch bunkern (ev. mit Hinweis: engl. stashed, je nach Kontext)
+|String|
+String; Singular: der String; Plural: die Strings; Vorzugsweise die englische Version nutzen, alternativ kann auch die deutsche Übersetzung „Zeichenkette“ verwendet werden.
 |Topic|
 Thema; Singular: das Thema; Plural: die Themen
 |to track|


### PR DESCRIPTION
Wie in Issue #49 diskutiert, hier mein Vorschlag zu String in den translation notes.

Ich habe überlegt, die Vorgabe zu machen, dass man in jeder Sektion bei erstmaliger Benutzung "Zeichenkette (engl. string)" schreiben soll. Das finde ich aber zu umständlich und restriktiv.