### PR TITLE
Erweiterung der Workflow-Dokumentation

### DIFF
--- a/TRANSLATION_NOTES_DE.asc
+++ b/TRANSLATION_NOTES_DE.asc
@@ -18,21 +18,21 @@ Wenn Sie an der deutschen Übersetzung mitarbeiten wollen, können Sie dazu ein 
 
 * Da bei der deutschen Übersetzung ausschließlich deutschsprachige Mitarbeiter mitwirken, sollte die Commit-Beschreibung auf Deutsch erfolgen. Bitte wenden Sie die üblichen Git Commit-Beschreibungskonventionen an.
 
-== Allgemeine Regeln
-
-* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
-* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
-* Der Leser wird formal mit „Sie“ angesprochen, wobei das „Sie“ auch großgeschrieben wird. Bitte beachten Sie dies auch bei Possessivpronomen, wie beispielsweise „Ihr“, „Ihre“ usw. gilt. Siehe hierzu auch link:http://www.duden.de/sprachwissen/sprachratgeber/gross-oder-kleinschreibung-von--em-du-du--em--und--em-ihr-ihr--em--1[folgender Link]. Andere Sprachen verwenden ebenfalls die formelle Form, wie link:https://github.com/progit/progit2/issues/151[hier] beschrieben.
-
 == Übersetzungs-Workflow
 
-* Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden. Alternativ können Sie direkt die Vorschau von beispielsweise https://atom.io/[Atom] verwenden.
-* Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
-* Für einen ersten Übersetzungsvorschlag können Sie Sie einen Absatz von Ihrem Browser in einen Übersetzer Ihrer Wahl kopieren. Vorschläge für Übersetzer-Tools:
-** https://www.deepl.com/translator[DeepL] übersetzt erstaunlich gut, auch mit englischen Fachbegriffen. Die Seite gibt sinnvolle Alternativen, wenn Sie auf ein übersetztes Wort klicken (z.B. bei du/Sie). In diversen (https://www.golem.de/news/deepl-im-hands-on-neues-tool-uebersetzt-viel-besser-als-google-und-microsoft-1708-129715.html[Kurz]-)https://www.reddit.com/r/TranslationStudies/comments/9ww6lo/google_translate_vs_deeplcom_which_is_better/[Tests] für teils deutlich besser als Google Translate befunden.
-** https://translate.google.com/[Google Translate], robuster Übersetzer
-** https://www.linguee.de/[Linguee] bietet Beispiel-Übersetzungen, die einen gesuchten Begriff enthalten. So kann man, je nach Kontext, entdecken wie der Begriff verwendet werden kann oder sollte.
-* Kopieren Sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
+* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
+
+* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
+
+* Beispiel fr einen gut funktionierenden Workflow für die Übersetzung
+** Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden.
+** Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
+** Für einen ersten Übersetzungsvorschlag, kopieren Sie einen Absatz von Ihrem Browser in https://www.deepl.com/translator[DeepL]. DeepL funktioniert auch mit englischen Fachbegriffen erstaunlich gut und gibt sinnvolle Alternativen, wenn Sie auf ein Wort klicken (z.B. bei du/Sie).
+** Kopieren sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
+
+== Allgemeine Regeln
+
+* Der Leser wird formal mit „Sie“ angesprochen, wobei das „Sie“ auch großgeschrieben wird. Bitte beachten Sie dies auch bei Possessivpronomen, wie beispielsweise „Ihr“, „Ihre“ usw. gilt. Siehe hierzu auch link:http://www.duden.de/sprachwissen/sprachratgeber/gross-oder-kleinschreibung-von--em-du-du--em--und--em-ihr-ihr--em--1[folgender Link]. Andere Sprachen verwenden ebenfalls die formelle Form, wie link:https://github.com/progit/progit2/issues/151[hier] beschrieben.
 
 == Schreibweise und Übersetzung von Fachbegriffen
 

--- a/TRANSLATION_NOTES_DE.asc
+++ b/TRANSLATION_NOTES_DE.asc
@@ -25,10 +25,13 @@ Wenn Sie an der deutschen Übersetzung mitarbeiten wollen, können Sie dazu ein 
 * Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
 
 * Beispiel für einen gut funktionierenden Workflow für die Übersetzung
-** Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden.
+** Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden. Alternativ können Sie direkt die Vorschau von beispielsweise https://atom.io/[Atom] verwenden.
 ** Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
-** Für einen ersten Übersetzungsvorschlag, kopieren Sie einen Absatz von Ihrem Browser in https://www.deepl.com/translator[DeepL]. DeepL funktioniert auch mit englischen Fachbegriffen erstaunlich gut und gibt sinnvolle Alternativen, wenn Sie auf ein Wort klicken (z.B. bei du/Sie).
-** Kopieren sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
+** Für einen ersten Übersetzungsvorschlag können Sie Sie einen Absatz von Ihrem Browser in einen Übersetzer Ihrer Wahl kopieren. Vorschläge für Übersetzer-Tools:
+*** https://www.deepl.com/translator[DeepL] übersetzt erstaunlich gut, auch mit englischen Fachbegriffen. Die Seite gibt sinnvolle Alternativen, wenn Sie auf ein übersetztes Wort klicken (z.B. bei du/Sie). In diversen (https://www.golem.de/news/deepl-im-hands-on-neues-tool-uebersetzt-viel-besser-als-google-und-microsoft-1708-129715.html[Kurz]-)https://www.reddit.com/r/TranslationStudies/comments/9ww6lo/google_translate_vs_deeplcom_which_is_better/[Tests] für teils deutlich besser als Google Translate befunden.
+*** https://translate.google.com/[Google Translate], robuster Übersetzer
+*** https://www.linguee.de/[Linguee] bietet Beispiel-Übersetzungen, die einen gesuchten Begriff enthalten. So kann man, je nach Kontext, entdecken wie der Begriff verwendet werden kann oder sollte.
+** Kopieren Sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
 
 == Allgemeine Regeln
 

--- a/TRANSLATION_NOTES_DE.asc
+++ b/TRANSLATION_NOTES_DE.asc
@@ -18,24 +18,21 @@ Wenn Sie an der deutschen Übersetzung mitarbeiten wollen, können Sie dazu ein 
 
 * Da bei der deutschen Übersetzung ausschließlich deutschsprachige Mitarbeiter mitwirken, sollte die Commit-Beschreibung auf Deutsch erfolgen. Bitte wenden Sie die üblichen Git Commit-Beschreibungskonventionen an.
 
-== Übersetzungs-Workflow
-
-* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
-
-* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
-
-* Beispiel für einen gut funktionierenden Workflow für die Übersetzung
-** Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden. Alternativ können Sie direkt die Vorschau von beispielsweise https://atom.io/[Atom] verwenden.
-** Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
-** Für einen ersten Übersetzungsvorschlag können Sie Sie einen Absatz von Ihrem Browser in einen Übersetzer Ihrer Wahl kopieren. Vorschläge für Übersetzer-Tools:
-*** https://www.deepl.com/translator[DeepL] übersetzt erstaunlich gut, auch mit englischen Fachbegriffen. Die Seite gibt sinnvolle Alternativen, wenn Sie auf ein übersetztes Wort klicken (z.B. bei du/Sie). In diversen (https://www.golem.de/news/deepl-im-hands-on-neues-tool-uebersetzt-viel-besser-als-google-und-microsoft-1708-129715.html[Kurz]-)https://www.reddit.com/r/TranslationStudies/comments/9ww6lo/google_translate_vs_deeplcom_which_is_better/[Tests] für teils deutlich besser als Google Translate befunden.
-*** https://translate.google.com/[Google Translate], robuster Übersetzer
-*** https://www.linguee.de/[Linguee] bietet Beispiel-Übersetzungen, die einen gesuchten Begriff enthalten. So kann man, je nach Kontext, entdecken wie der Begriff verwendet werden kann oder sollte.
-** Kopieren Sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
-
 == Allgemeine Regeln
 
+* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
+* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
 * Der Leser wird formal mit „Sie“ angesprochen, wobei das „Sie“ auch großgeschrieben wird. Bitte beachten Sie dies auch bei Possessivpronomen, wie beispielsweise „Ihr“, „Ihre“ usw. gilt. Siehe hierzu auch link:http://www.duden.de/sprachwissen/sprachratgeber/gross-oder-kleinschreibung-von--em-du-du--em--und--em-ihr-ihr--em--1[folgender Link]. Andere Sprachen verwenden ebenfalls die formelle Form, wie link:https://github.com/progit/progit2/issues/151[hier] beschrieben.
+
+== Übersetzungs-Workflow
+
+* Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden. Alternativ können Sie direkt die Vorschau von beispielsweise https://atom.io/[Atom] verwenden.
+* Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
+* Für einen ersten Übersetzungsvorschlag können Sie Sie einen Absatz von Ihrem Browser in einen Übersetzer Ihrer Wahl kopieren. Vorschläge für Übersetzer-Tools:
+** https://www.deepl.com/translator[DeepL] übersetzt erstaunlich gut, auch mit englischen Fachbegriffen. Die Seite gibt sinnvolle Alternativen, wenn Sie auf ein übersetztes Wort klicken (z.B. bei du/Sie). In diversen (https://www.golem.de/news/deepl-im-hands-on-neues-tool-uebersetzt-viel-besser-als-google-und-microsoft-1708-129715.html[Kurz]-)https://www.reddit.com/r/TranslationStudies/comments/9ww6lo/google_translate_vs_deeplcom_which_is_better/[Tests] für teils deutlich besser als Google Translate befunden.
+** https://translate.google.com/[Google Translate], robuster Übersetzer
+** https://www.linguee.de/[Linguee] bietet Beispiel-Übersetzungen, die einen gesuchten Begriff enthalten. So kann man, je nach Kontext, entdecken wie der Begriff verwendet werden kann oder sollte.
+* Kopieren Sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
 
 == Schreibweise und Übersetzung von Fachbegriffen
 

--- a/TRANSLATION_NOTES_DE.asc
+++ b/TRANSLATION_NOTES_DE.asc
@@ -18,21 +18,21 @@ Wenn Sie an der deutschen Übersetzung mitarbeiten wollen, können Sie dazu ein 
 
 * Da bei der deutschen Übersetzung ausschließlich deutschsprachige Mitarbeiter mitwirken, sollte die Commit-Beschreibung auf Deutsch erfolgen. Bitte wenden Sie die üblichen Git Commit-Beschreibungskonventionen an.
 
-== Übersetzungs-Workflow
-
-* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
-
-* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
-
-* Beispiel fr einen gut funktionierenden Workflow für die Übersetzung
-** Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden.
-** Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
-** Für einen ersten Übersetzungsvorschlag, kopieren Sie einen Absatz von Ihrem Browser in https://www.deepl.com/translator[DeepL]. DeepL funktioniert auch mit englischen Fachbegriffen erstaunlich gut und gibt sinnvolle Alternativen, wenn Sie auf ein Wort klicken (z.B. bei du/Sie).
-** Kopieren sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
-
 == Allgemeine Regeln
 
+* Falls Sie einen Abschnitt übersetzen möchten, der noch nicht übersetzt wurde, sollten Sie nach der Übersetzung den englischen Text entfernen. Bitte entfernen Sie den englischen Text nur für die Passagen, die Sie auch tatsächlich bereits übersetzt haben.
+* Kommandozeilenausgaben sollten so übersetzt werden, dass sie mit der deutschen Version von Git übereinstimmen. Im Zweifel belassen Sie bitte die Kommandozeilenausgabe in Englisch.
 * Der Leser wird formal mit „Sie“ angesprochen, wobei das „Sie“ auch großgeschrieben wird. Bitte beachten Sie dies auch bei Possessivpronomen, wie beispielsweise „Ihr“, „Ihre“ usw. gilt. Siehe hierzu auch link:http://www.duden.de/sprachwissen/sprachratgeber/gross-oder-kleinschreibung-von--em-du-du--em--und--em-ihr-ihr--em--1[folgender Link]. Andere Sprachen verwenden ebenfalls die formelle Form, wie link:https://github.com/progit/progit2/issues/151[hier] beschrieben.
+
+== Übersetzungs-Workflow
+
+* Falls Sie eine Live-Vorschau der von Ihnen bearbeiteten Datei möchten: Installieren Sie https://asciidoctor.org/docs/editing-asciidoc-with-live-preview/[AsciiDoc Live Preview] im Browser Ihrer Wahl und öffnen Sie die zu übersetzende .asc-Datei in diesem Browser. AsciiDoc Live Preview lädt Dateien automatisch neu, wenn diese überschrieben werden. Alternativ können Sie direkt die Vorschau von beispielsweise https://atom.io/[Atom] verwenden.
+* Öffnen Sie die .asc-Datei mit einem Texteditor Ihrer Wahl.
+* Für einen ersten Übersetzungsvorschlag können Sie Sie einen Absatz von Ihrem Browser in einen Übersetzer Ihrer Wahl kopieren. Vorschläge für Übersetzer-Tools:
+** https://www.deepl.com/translator[DeepL] übersetzt erstaunlich gut, auch mit englischen Fachbegriffen. Die Seite gibt sinnvolle Alternativen, wenn Sie auf ein übersetztes Wort klicken (z.B. bei du/Sie). In diversen (https://www.golem.de/news/deepl-im-hands-on-neues-tool-uebersetzt-viel-besser-als-google-und-microsoft-1708-129715.html[Kurz]-)https://www.reddit.com/r/TranslationStudies/comments/9ww6lo/google_translate_vs_deeplcom_which_is_better/[Tests] für teils deutlich besser als Google Translate befunden.
+** https://translate.google.com/[Google Translate], robuster Übersetzer
+** https://www.linguee.de/[Linguee] bietet Beispiel-Übersetzungen, die einen gesuchten Begriff enthalten. So kann man, je nach Kontext, entdecken wie der Begriff verwendet werden kann oder sollte.
+* Kopieren Sie den von DeepL übersetzten Text in Ihren Texteditor und nehmen Sie letzte Korrekturen wie das Markieren von Code mit Backticks (`) vor.
 
 == Schreibweise und Übersetzung von Fachbegriffen
 


### PR DESCRIPTION
- Google Translate und Linguee hinzugefügt
- Atom hinzugefügt
- Vergleiche DeepL vs Google Translate hinzugefügt
- Bisherige Workflow-Hinweise zu "Allgemeine Regeln verschoben" und eigenen Abschnitt für Workflow erstellt, um das zweichfache Einrücken der Übersetzerliste zu vermeiden.

Danke @max123kl für die gute Beschreibung von Linguee, die habe ich fast 1:1 übernommen ;)