### PR TITLE
fix doppeltes wird

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -114,7 +114,7 @@ Changes not staged for commit:
 Die Datei `CONTRIBUTING.md` erscheint im Abschnitt „Changed but not staged for commit“ – das bedeutet, dass eine versionierte Datei im Arbeitsverzeichnis verändert worden ist, aber noch nicht für den Commit vorgemerkt wurde.
 Um sie vorzumerken, führen Sie den Befehl `git add` aus.
 Der Befehl `git add` wird zu vielen verschiedenen Zwecken eingesetzt. Man verwendet ihn, um neue Dateien zur Versionsverwaltung hinzuzufügen, Dateien für einen Commit vorzumerken und verschiedene andere Dinge – beispielsweise, einen Konflikt aus einem Merge als aufgelöst zu kennzeichnen.
-Leider wird der Befehl `git add` oft missverstanden, viele assoziieren damit, dass damit Dateien zum Projekt hinzufügt werden. Wie Sie aber gerade gelernt haben, wird der Befehl auch noch für viele andere Dinge eingesetzt. Wenn Sie den Befehl `git add` einsetzen, sollten Sie das eher so sehen, dass Sie damit einen bestimmten Inhalt für den nächsten Commit vormerken.(((Git Befehle, add)))
+Leider wird der Befehl `git add` oft missverstanden, viele assoziieren damit, dass damit Dateien zum Projekt hinzugefügt werden. Wie Sie aber gerade gelernt haben, wird der Befehl auch noch für viele andere Dinge eingesetzt. Wenn Sie den Befehl `git add` einsetzen, sollten Sie das eher so sehen, dass Sie damit einen bestimmten Inhalt für den nächsten Commit vormerken.(((Git Befehle, add)))
 Lassen Sie uns nun mit `git add` die Datei `CONTRIBUTING.md` zur Staging-Area hinzufügen und danach das Ergebnis mit `git status` kontrollieren:
 
 [source,console]

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -114,7 +114,7 @@ Changes not staged for commit:
 Die Datei `CONTRIBUTING.md` erscheint im Abschnitt „Changed but not staged for commit“ – das bedeutet, dass eine versionierte Datei im Arbeitsverzeichnis verändert worden ist, aber noch nicht für den Commit vorgemerkt wurde.
 Um sie vorzumerken, führen Sie den Befehl `git add` aus.
 Der Befehl `git add` wird zu vielen verschiedenen Zwecken eingesetzt. Man verwendet ihn, um neue Dateien zur Versionsverwaltung hinzuzufügen, Dateien für einen Commit vorzumerken und verschiedene andere Dinge – beispielsweise, einen Konflikt aus einem Merge als aufgelöst zu kennzeichnen.
-Leider wird der Befehl `git add` wird oft missverstanden, viele assoziieren damit, dass damit Dateien zum Projekt hinzufügt werden. Wie Sie aber gerade gelernt haben, wird der Befehl auch noch für viele andere Dinge eingesetzt. Wenn Sie den Befehl `git add` einsetzen, sollten Sie das eher so sehen, dass Sie damit einen bestimmten Inhalt für den nächsten Commit vormerken.(((Git Befehle, add)))
+Leider wird der Befehl `git add` oft missverstanden, viele assoziieren damit, dass damit Dateien zum Projekt hinzufügt werden. Wie Sie aber gerade gelernt haben, wird der Befehl auch noch für viele andere Dinge eingesetzt. Wenn Sie den Befehl `git add` einsetzen, sollten Sie das eher so sehen, dass Sie damit einen bestimmten Inhalt für den nächsten Commit vormerken.(((Git Befehle, add)))
 Lassen Sie uns nun mit `git add` die Datei `CONTRIBUTING.md` zur Staging-Area hinzufügen und danach das Ergebnis mit `git status` kontrollieren:
 
 [source,console]


### PR DESCRIPTION
Im Satz wurde „wird“ zweimal verwendet.