### PR TITLE
fix, twice `a/b/c/z

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -227,7 +227,7 @@ Die Richtlinien für Vergleichsmuster, die Sie in der Datei `.gitignore` eingebe
 
 Platzhalter-Zeichen sind wie einfache, reguläre Ausdrücke, die von der Shell genutzt werden.
 Ein Sternchen (`*`) entspricht null oder mehr Zeichen; `[abc]` entspricht jedem Zeichen innerhalb der eckigen Klammern (in diesem Fall a, b oder c); ein Fragezeichen (`?`) entspricht einem einzelnen Zeichen und eckige Klammern, die durch einen Bindestrich (`[0-9]`) getrennte Zeichen einschließen, passen zu jedem Zeichen dazwischen (in diesem Fall von 0 bis 9).
-Sie können auch zwei Sterne verwenden, um verschachtelte Verzeichnisse abzugleichen; `a/**/z` würde zu `a/z`, `a/b/z`, `a/b/c/z`, `a/b/c/z`, usw. passen.
+Sie können auch zwei Sterne verwenden, um verschachtelte Verzeichnisse abzugleichen; `a/**/z` würde zu `a/z`, `a/b/z`, `a/b/c/z`, usw. passen.
 
 Hier ist eine weitere `.gitignore` Beispieldatei:
 


### PR DESCRIPTION
Double entry removed.