### PR TITLE
spelling fixes for git svn

### DIFF
--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -71,7 +71,7 @@ Copied properties for revision 2.
 […]
 ----
 
-Obwohl dieser Vorgang nur wenige Minutenin Anspruch nehmen könnte, dauert der Prozess fast eine Stunde, wenn Sie versuchen, das ursprüngliche Repository in ein anderes Remote-Repository anstelle eines lokalen zu kopieren, obwohl es weniger als 100 Commits gibt.
+Obwohl dieser Vorgang nur wenige Minuten in Anspruch nehmen könnte, dauert der Prozess fast eine Stunde, wenn Sie versuchen, das ursprüngliche Repository in ein anderes Remote-Repository anstelle eines lokalen zu kopieren, obwohl es weniger als 100 Commits gibt.
 Subversion muss eine Revision nach der anderen klonen und sie dann wieder in ein anderes Repository verschieben – es ist unvorstellbar ineffizient, aber es ist der einzige einfache Weg, das zu erreichen.
 
 ===== Erste Schritte
@@ -339,7 +339,7 @@ Wenn jemand anderes diese Arbeit klont, sieht man nur den Merge-Commit mit der g
 Branching in Subversion ist nicht dasselbe wie Branching in Git. Es ist wahrscheinlich das Beste, wenn Sie es so oft vermeiden wie möglich.
 Sie können aber mit `git svn` in Subversion Branches anlegen und dorthin committen.
 
-===== Creating a New SVN Branch
+===== Erstellen eines neuen SVN Branches
 
 Um einen neuen Branch in Subversion zu erstellen, führen Sie `git svn branch [new-branch]` aus:
 
@@ -355,7 +355,8 @@ r91 = f1b64a3855d3c8dd84ee0ef10fa89d27f1584302 (refs/remotes/origin/opera)
 ----
 
 Dadurch wird das Äquivalent des Befehls `svn copy trunk branches/opera` in Subversion ausgeführt und auf dem Subversion-Server angewendet.
-Wichtig dabei ist, dass er Sie nicht in diesen Branch auscheckt; wenn Sie an dieser Stelle committen, wird dieser Commit in den `trunk` auf dem Server gehen, nicht in at this point, that commit will go to `trunk` on the server, not `opera`.
+Es ist wichtig zu beachten, dass Sie nicht in diesen Zweig ausgecheckt werden; wenn Sie an diesem Punkt einen Commit durchführen,
+geht dieser Commit in den `trunk` auf dem Server, nicht in `opera`.
 
 ===== Aktive Branches wechseln
 

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -125,8 +125,8 @@ Da `master` in Git eher idiomatisch ist, hier die Anleitung zum Entfernen des ex
 $ git branch -d trunk
 ----
 
-Das Letzte, was Sie tun müssen, ist, Ihren neuen Git-Server als Remote hinzuzufügen und ihn zu aktivieren.
-Hier ist ein Beispiel für das Hinzufügen Ihres Servers als Remote:
+Das Letzte, was Sie tun müssen, ist, Ihren neuen Git-Server als Remote hinzuzufügen und zu ihn zu pushen.
+Hier ist ein Beispiel für das hinzufügen Ihres Servers als Remote:
 
 [source,console]
 ----

--- a/book/09-git-and-other-scms/sections/import-svn.asc
+++ b/book/09-git-and-other-scms/sections/import-svn.asc
@@ -125,7 +125,7 @@ Da `master` in Git eher idiomatisch ist, hier die Anleitung zum Entfernen des ex
 $ git branch -d trunk
 ----
 
-Das Letzte, was Sie tun müssen, ist, Ihren neuen Git-Server als Remote hinzuzufügen und zu ihn zu pushen.
+Das Letzte, was Sie tun müssen, ist, Ihren neuen Git-Server als Remote hinzuzufügen und zu ihm zu pushen.
 Hier ist ein Beispiel für das hinzufügen Ihres Servers als Remote:
 
 [source,console]


### PR DESCRIPTION
Korrekturen für Kapitel 10 git svn.
Ich habe mir nur den SVN teil angeschaut die andren sind für mich gerade nicht relevant.
