### PR TITLE
kompaktere Hilfeseiten mit -h, nicht mit --help

### DIFF
--- a/book/01-introduction/sections/help.asc
+++ b/book/01-introduction/sections/help.asc
@@ -21,7 +21,7 @@ Diese Befehle sind nützlich, weil Sie sich die Hilfe jederzeit anzeigen lassen 
 Wenn die Hilfeseiten und dieses Buch nicht ausreichen und Sie persönliche Hilfe brauchen, können Sie einen der Kanäle `#git` oder `#github` auf dem Freenode-IRC-Server probieren, der unter https://freenode.net zu finden ist.
 Diese Kanäle sind in der Regel sehr gut besucht. Normalerweise findet sich unter den vielen Anwendern, die oft sehr viel Erfahrung mit Git haben, irgendjemand, der Ihnen weiterhelfen kann.(((IRC-Chat)))
 
-Wenn Sie nicht die vollständige Manpage-Hilfe benötigen, sondern nur eine kurze Beschreibung der verfügbaren Optionen für einen Git-Befehl, können Sie auch in den kompakteren „Hilfeseiten“ mit der Option `-h` oder `--help` nachschauen, wie in:
+Wenn Sie nicht die vollständige Manpage-Hilfe benötigen, sondern nur eine kurze Beschreibung der verfügbaren Optionen für einen Git-Befehl, können Sie auch in den kompakteren „Hilfeseiten“ mit der Option `-h` nachschauen, wie in:
 
 [source,console]
 ----


### PR DESCRIPTION
In der englischen Vorlage ist dies bereits korrekt:
https://www.git-scm.com/book/en/v2/Getting-Started-Getting-Help

- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- remove '--help' which is wrong here because it prints the "long" help / manpage
