### PR TITLE
Fix typo in 6.2

### DIFF
--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -430,7 +430,7 @@ How big are these slings and in particular, these arrows?
 Nach dem Rendern sieht der Kommentar wie folgt aus: <<_md_quote>>.
 
 [[_md_quote]]
-.gerenderes Zitat-Beispiel
+.gerendertes Zitat-Beispiel
 image::images/markdown-05-quote.png[Rendered quoting]
 
 ===== Emojis


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Fix small typo "gerenderes" instead of "gerendertes" (missing a "t") in chapter 6.2