### PR TITLE
Missverständlichkeit behoben

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -549,7 +549,6 @@ Mit anderen Worten, Sie können die Datei auf Ihrer Festplatte behalten, aber ni
 
 Das ist besonders dann nützlich, wenn Sie vergessen haben, etwas zu Ihrer Datei `.gitignore` hinzuzufügen und dies versehentlich „gestaged“ haben (eine große Logdatei z.B. oder eine Reihe von .a-kompilierten Dateien).
 Das erreichen Sie mit der Option `--cached`:
-
 [source,console]
 ----
 $ git rm --cached README

--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -546,7 +546,8 @@ Hierbei handelt es sich um eine Sicherheitsfunktion, die ein versehentliches Ent
 
 Eine weitere nützliche Sache, die Sie möglicherweise nutzen möchten, ist, die Datei in Ihrem Verzeichnisbaum zu behalten, sie aber aus Ihrer Staging-Area zu entfernen.
 Mit anderen Worten, Sie können die Datei auf Ihrer Festplatte behalten, aber nicht mehr von Git protokollieren/versionieren lassen.
-Das ist besonders dann nützlich, wenn Sie vergessen haben, etwas zu Ihrer `.gitignore` Datei hinzuzufügen und diese versehentlich „gestaged“ haben, wie eine große Logdatei oder eine Reihe von `.a`-kompilierten Dateien.
+
+Das ist besonders dann nützlich, wenn Sie vergessen haben, etwas zu Ihrer Datei `.gitignore` hinzuzufügen und dies versehentlich „gestaged“ haben (eine große Logdatei z.B. oder eine Reihe von .a-kompilierten Dateien).
 Das erreichen Sie mit der Option `--cached`:
 
 [source,console]


### PR DESCRIPTION
Ich bin über den ursprünglichen Satz gestolpert, und habe beim ersten Lesen verstanden, es ginge um die Datei .gitignore, die unbeabsichtigt in der Staging-Area gelandet ist. "(...) wenn Sie vergessen haben, etwas zu Ihrer .gitignore Datei hinzuzufügen und diese(!) versehentlich „gestaged“ haben." Das "diese" bezieht sich üblicherweise auf das letzte Objekt (".gitignore Datei") und nicht auf "etwas".  Im englischen Original ist der Bezug unmissverständlich "something" und nicht "your .gitignore file". Zuguterletzt werden Komposita (zusammengesetzte Wörter) mit einem Bindestrich verbunden. Es hieße also eigentlich "zu Ihrer .gitignore-Datei". Das sieht ein bisschen sperrig aus. Deswegen mein Vorschlag "zur Ihrer Datei .gitignore".

Im übrigen wollte ich schon gestern loswerden, dass die Übersetzung wirklich sehr gelungen und das Lesen ein Genuss ist. Schöne Grüße an alle Übersetzer.

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- 

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.
Fixes #123
Fixes #456
-->