### PR TITLE
Kommafehler

### DIFF
--- a/book/02-git-basics/sections/viewing-history.asc
+++ b/book/02-git-basics/sections/viewing-history.asc
@@ -1,7 +1,7 @@
 [[_viewing_history]]
 === Anzeigen der Commit-Historie
 
-Nachdem Sie mehrere Commits erstellt haben oder wenn Sie ein Repository mit einer bestehenden Commit-Historie geklont haben, werden Sie wahrscheinlich zurückschauen wollen, um zu erfahren, was geschehen ist.
+Nachdem Sie mehrere Commits erstellt haben, oder wenn Sie ein Repository mit einer bestehenden Commit-Historie geklont haben, werden Sie wahrscheinlich zurückschauen wollen, um zu erfahren, was geschehen ist.
 Das wichtigste und mächtigste Werkzeug dafür ist der Befehl `git log`.
 
 Diese Beispiele verwenden ein sehr einfaches Projekt namens „simplegit“.


### PR DESCRIPTION
Vor dem Nebensatz, auch wenn er mit "oder" eingeleitet wird, muss ein Komma. Im Abschnitt "ungewollte Änderungen rückgängig machen" ist es z.B. korrekt: "Eines der häufigsten Undos tritt auf, wenn Sie zu früh committen und möglicherweise vergessen, einige Dateien hinzuzufügen, oder wenn Sie Ihre Commit-Nachricht durcheinander bringen."

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- 

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.
Fixes #123
Fixes #456
-->