### PR TITLE
Etwas weniger kompromisslos formulieren

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -138,7 +138,7 @@ Sie können erkennen, dass die Änderungen rückgängig gemacht wurden.
 =====
 Es ist sehr wichtig zu begreifen, dass `git checkout -- <file>` ein riskanter Befehl ist.
 Alle lokalen Änderungen, die Sie an dieser Datei vorgenommen haben, sind verloren – Git hat diese Datei einfach durch die zuletzt committete oder gestagten Version ersetzt.
-Verwenden Sie diesen Befehl niemals, es sei denn, Sie sind sich absolut sicher, dass Sie diese ungesicherten lokalen Änderungen nicht wünschen.
+Verwenden Sie diesen Befehl nur, wenn Sie sich absolut sicher sind, dass Sie diese nicht gespeicherten lokalen Änderungen nicht benötigen.
 =====
 
 Wenn Sie die Änderungen, die Sie an dieser Datei gemacht haben, beibehalten möchten, sie aber vorerst aus dem Weg räumen möchten, sollten wir das Stashing und Branching in Kapitel 3 – <<ch03-git-branching#ch03-git-branching,Git Branching>> durchgehen; das sind im Allgemeinen die besseren Methoden, um das zu erledigen.


### PR DESCRIPTION
Im Abschnitt, der die Alternative über "git restore" erklärt, ist es weniger dramatisch formuliert. Das sollte übernommen werden, denke ich.

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- 

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.
Fixes #123
Fixes #456
-->