### PR TITLE
Kleine Satzumstellung, Übersetzungsmissverständnis

### DIFF
--- a/book/02-git-basics/sections/remotes.asc
+++ b/book/02-git-basics/sections/remotes.asc
@@ -102,8 +102,8 @@ From https://github.com/paulboone/ticgit
  * [new branch]      ticgit     -> pb/ticgit
 ----
 
-Pauls `master` Branch ist nun lokal als `pb/master` erreichbar – Sie können ihn in eine Ihrer Branches einbinden oder Sie können an dieser Stelle in einen lokalen Branch wechseln (engl. checkout), wenn Sie ihn inspizieren möchten.
-(Wir werden in <<ch03-git-branching#ch03-git-branching,Git Branching>> näher darauf eingehen, was Branches sind und wie man sie viel präziser nutzen kann.)
+Pauls `master` Branch ist nun lokal als `pb/master` erreichbar – Sie können ihn in eine Ihrer Branches einbinden oder an dieser Stelle in einen lokalen Branch wechseln (engl. checkout), wenn Sie ihn inspizieren möchten.
+Wir werden in <<ch03-git-branching#ch03-git-branching,Git Branching>> detailliert beschreiben, was Branches sind und wie man sie nutzt.
 
 [[_fetching_and_pulling]]
 ==== Fetchen und Pullen von Ihren Remotes


### PR DESCRIPTION
1. Unschön: "Sie können (...), oder Sie können"
2. Im Original heißt es "(...) what branches are and how to use them in much more detail in 'Git Branching'". Das ist ein Hinweis wo sie (Branches) präzise beschrieben werden und nicht, wie man sie "präziser" nutzt.

<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- 

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.
Fixes #123
Fixes #456
-->