### PR TITLE
Typo removed whitespaces

### DIFF
--- a/book/05-distributed-git/sections/maintaining.asc
+++ b/book/05-distributed-git/sections/maintaining.asc
@@ -322,7 +322,7 @@ Das ist wahrscheinlich der einfachste Workflow. Es kann jedoch zu Problemen komm
 Wenn Sie ein wichtigeres Projekt haben, möchten Sie möglicherweise einen zweistufigen Merge Prozess verwenden.
 In diesem Szenario haben Sie zwei lange laufende Branches namens `master` und `develop`. Sie legen fest, dass `master` nur dann aktualisiert wird, wenn eine sehr stabile Version vorhanden ist und der gesamte neue Code in den Branch `develop` integriert wird.
 Sie pushen diese beiden Branches regelmäßig in das öffentliche Repository.
-Jedes Mal, wenn Sie einen neuen Branch zum Zusammenführen haben (<<merwf_c>>), führen Sie ihn in `develop` (<< merwf_d >>) zusammen. Wenn Sie nun ein Release mit einem Tag versehen, spulen Sie `master` an die Stelle weiter, an der sich der jetzt stabile `develop` Branch befindet (<<merwf_e>>).
+Jedes Mal, wenn Sie einen neuen Branch zum Zusammenführen haben (<<merwf_c>>), führen Sie ihn in `develop` (<<merwf_d>>) zusammen. Wenn Sie nun ein Release mit einem Tag versehen, spulen Sie `master` an die Stelle weiter, an der sich der jetzt stabile `develop` Branch befindet (<<merwf_e>>).
 
 [[merwf_c]]
 .Vor einem Themen Branch Merge


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- removed whitespaces in reference

## Context

With included whitespaces the reference will not be solved. Ss a result reference name is printed out.
With this pull-request, the issue should be fixed.

Please see attached screenshot which hightlights the printed reference.
![git_typo](https://github.com/progit/progit2-de/assets/11159471/871b40c7-71b9-4ecb-a737-abc2a75470f7)
