### PR TITLE
fix: Grammatik & unpräzise übersetzung

### DIFF
--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -1,7 +1,7 @@
 === GitLab
 
 (((Server-Repositorys, GitLab)))(((GitLab)))
-GitWeb ist jedoch ein recht übersichtliches Tool.
+GitWeb ist jedoch ein recht minimalistisches Tool.
 Wenn du einen modernen, voll ausgestatteten Git-Server suchst, gibt es einige Open-Source-Lösungen, die du stattdessen installieren kannst.
 Da GitLab einer der beliebtesten ist, werden wir uns mit der Installation im Detail befassen und es als Beispiel verwenden.
 Dies ist etwas schwieriger als die GitWeb-Option und erfordert mehr Wartung, aber es ist eine viel umfassendere Lösung.
@@ -23,7 +23,7 @@ Weitere Informationen findest du in der Readme-Datei https://gitlab.com/gitlab-o
 
 ==== Administration
 
-Die Verwaltungsoberfläche von GitLab wird ist webbasiert.
+Die Verwaltungsoberfläche von GitLab wird webbasiert bereitgestellt.
 Benutze einfach deinen Browser, um den Hostnamen oder die IP-Adresse, auf der GitLab installiert ist, anzugeben, und melden dich als Admin-Benutzer an.
 Der Standardbenutzername ist `admin@local.host`, das Standardpasswort ist `5iveL!fe` (dies muss nach der Eingabe *geändert werden*).
 Klicke nach der Anmeldung im Menü oben rechts auf das Symbol „Admin-Bereich“.
@@ -44,9 +44,9 @@ Wenn der Benutzer +jane+ ein Projekt mit dem Namen +project+ hätte, wäre die U
 image::images/gitlab-users.png[Das Fenster der Benutzerverwaltung von GitLab]
 
 Das Löschen eines Benutzers kann auf zwei Arten erfolgen.
-Das „Blockieren“ eines Benutzers verhindert, dass er sich am GitLab anmeldet. Alle Daten unter den Namensraum dieses Benutzers bleiben jedoch erhalten. Mit der E-Mail-Adresse dieses Benutzers signierte Commits werden weiterhin mit seinem Profil verknüpft.
+Das „Sperren“ eines Benutzers verhindert, dass er sich am GitLab anmeldet. Alle Daten unter den Namensraum dieses Benutzers bleiben jedoch erhalten. Mit der E-Mail-Adresse dieses Benutzers signierte Commits werden weiterhin mit seinem Profil verknüpft.
 
-Das „Zerstören“ eines Benutzers hingegen entfernt ihn vollständig aus der Datenbank und dem Dateisystem.
+Das „Löschen“ eines Benutzers hingegen entfernt ihn vollständig aus der Datenbank und dem Dateisystem.
 Alle Projekte und Daten in seinem Namensraum werden entfernt, und alle Gruppen, die sich in seinem Besitz befinden, werden ebenfalls entfernt.
 Das ist eine permanente und destruktive Aktion, die in der Regel selten angewendet wird.
 


### PR DESCRIPTION
- [X] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [X] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Grammatik korrigiert
- 'simplistic' Übersetzung von 'übersichtlich' in 'minimalistisch' geändert, was Sinngemäßer erscheint
- Beschreibung der Nutzer-Operationen in von GitLab genutzte Begriffe geändert
