### PR TITLE
Fix typos in CONTRIBUTING.asc

### DIFF
--- a/CONTRIBUTING.asc
+++ b/CONTRIBUTING.asc
@@ -22,7 +22,7 @@ Wenn du dies noch nie zuvor getan hast, kann der link:https://guides.github.com/
 
 == Größere Änderungen
 
-Öffnen einen Issue zur Diskussion, bevor du beginnst.
+Öffne einen Issue zur Diskussion, bevor du beginnst.
 Eine umfangreiche Korrektur neigt dazu, sehr subjektiv zu sein und die Dinge oft nur für eine kleinere Anzahl von Lesern zu verbessern.
 Professionelle Textredakteure haben diesen Inhalt bereits mehrfach überprüft.
 Es ist unwahrscheinlich, dass deine neue Textfassung *so* viel besser wird, dass es sich lohnt, große Teile des Inhalts zu ändern.
@@ -37,7 +37,7 @@ Um eine Abbildung zu erstellen:
 Verwende, wo immer möglich, die mitgelieferten Symbole.
 2. Füge deine Seite einen „Slice“ hinzu.
 Gib ihm einen Namen, der mit dem PNG-Dateinamen des Ziels übereinstimmt, relativ zur Root des Quellverzeichnisses.
-3. Stelle den Export Ihres Slice auf „800w“ ein.
+3. Stelle den Export deines Slice auf „800w“ ein.
 
 == Übersetzungen
 


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/progit/progit2/blob/main/LICENSE.asc).
- [x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

Bereinigt weitere Artefakte der Sie -> Du Umstellung
 

